### PR TITLE
Discussion about X-Goog-Firebase-Installations-Auth

### DIFF
--- a/pentesting-cloud/gcp-security/gcp-services/gcp-databases-enum/gcp-firebase-enum.md
+++ b/pentesting-cloud/gcp-security/gcp-services/gcp-databases-enum/gcp-firebase-enum.md
@@ -69,6 +69,8 @@ To test other actions on the database, such as writing to the database, refer to
 
 If you decompile the iOS application and open the file `GoogleService-Info.plist` and you find the API Key and APP ID:
 
+You can also get these values by listening for requests and decoding the JWT token in the `X-Goog-Firebase-Installations-Auth` header.
+
 * API KEY **AIzaSyAs1\[...]**
 * APP ID **1:612345678909:ios:c212345678909876**
 


### PR DESCRIPTION
I noticed that you don't have to decompile a iOS application to figure out these two values as you can just decode the JWT value in the X-Goog-Firebase-Installations-Auth and look for the API key in the requests. However I cannot find any valid sources to back up my claims as there is nothing from Google itself stating how X-Goog-Firebase-Installations-Auth works. 

Before we pull this request in we should discuss if this is correct undocumented behavior which will can use to speed up testing as we don't have to decompile if we can reliability assume these values by looking at the requests.