### PR TITLE
arte-Kayn

### DIFF
--- a/pentesting-cloud/aws-security/aws-post-exploitation/aws-ec2-ebs-ssm-and-vpc-post-exploitation/aws-ebs-snapshot-dump.md
+++ b/pentesting-cloud/aws-security/aws-post-exploitation/aws-ec2-ebs-ssm-and-vpc-post-exploitation/aws-ebs-snapshot-dump.md
@@ -14,24 +14,13 @@ Other ways to support HackTricks:
 
 </details>
 
-### Checking a snapshot locally
+### Checking a snapshot locally (DEPRECATED)
+Neither AWS CLI, dsnap or pacu support snapshot dump anymore for publicly accessible snapshots. However, in case you are able to get it locally somehow, the following commands can be used to mount it.
 
 ```bash
 # Install dependencies
-pip install 'dsnap[cli]'
 brew install vagrant
 brew install virtualbox
-
-# Get snapshot from image
-mkdir snap_wordir; cd snap_workdir
-dsnap init
-## Download a snapshot of the volume of that instance
-## If no snapshot existed it will try to create one
-dsnap get <instance-id>
-dsnap --profile default --region eu-west-1 get i-0d706e33814c1ef9a
-## Other way to get a snapshot
-dsnap list #List snapshots
-dsnap get snap-0dbb0347f47e38b96 #Download snapshot directly
 
 # Run with vagrant
 IMAGE="<download_file>.img" vagrant up #Run image with vagrant+virtuabox
@@ -47,7 +36,6 @@ IMAGE="<download_file>.img" make docker/run #With the snapshot downloaded
 
 For more info on this technique check the original research in [https://rhinosecuritylabs.com/aws/exploring-aws-ebs-snapshots/](https://rhinosecuritylabs.com/aws/exploring-aws-ebs-snapshots/)
 
-You can do this with Pacu using the module [ebs\_\_download\_snapshots](https://github.com/RhinoSecurityLabs/pacu/wiki/Module-Details#ebs\_\_download\_snapshots)
 
 ### Checking a snapshot in AWS
 


### PR DESCRIPTION
The public snapshot dump is no longer a supported feature in pacu or any other open-source tool. Therfore, this method should be mentioned as deprecated.
