### PR TITLE
fix(aws-glue-privesc.md): add condition on glue pass-role attack

### DIFF
--- a/pentesting-cloud/aws-security/aws-privilege-escalation/aws-glue-privesc.md
+++ b/pentesting-cloud/aws-security/aws-privilege-escalation/aws-glue-privesc.md
@@ -18,7 +18,7 @@ Other ways to support HackTricks:
 
 ### `iam:PassRole`, `glue:CreateDevEndpoint`, (`glue:GetDevEndpoint` | `glue:GetDevEndpoints`)
 
-Users with these permissions can **set up a new AWS Glue development endpoin**t, **assigning an existing service role** with specific permissions to this endpoint.
+Users with these permissions can **set up a new AWS Glue development endpoint**, **assigning an existing service role assumable by Glue** with specific permissions to this endpoint.
 
 After the setup, the **attacker can SSH into the endpoint's instance**, and steal the IAM credentials of the assigned role:
 


### PR DESCRIPTION
You can remove this content before sending the PR:

## Attribution
We value your knowledge and encourage you to share content. Please ensure that you only upload content that you own or that have permission to share it from the original author (adding a reference to the author in the added text or at the end of the page you are modifying or both). Your respect for intellectual property rights fosters a trustworthy and legal sharing environment for everyone.

## HackTricks Training
If you are adding so you can pass the in the [ARTE certification](https://training.hacktricks.xyz/courses/arte) exam with 2 flags instead of 3, you need to call the PR `arte-<username>`.

Also, remember that grammar/syntax fixes won't be accepted for the exam flag reduction.


In any case, thanks for contributing to HackTricks!
