### PR TITLE
s/PTR/PRT/g

### DIFF
--- a/pentesting-cloud/azure-security/az-lateral-movement-cloud-on-prem/pass-the-prt.md
+++ b/pentesting-cloud/azure-security/az-lateral-movement-cloud-on-prem/pass-the-prt.md
@@ -58,7 +58,7 @@ The **LSASS** process will send to the TPM the **KDF context**, and the TPM will
 
 The **KDF context is** a nonce from AzureAD and the PRT creating a **JWT** mixed with a **context** (random bytes).
 
-Therefore, even if the PTR cannot be extracted because it's located inside the TPM, it's possible to abuseLSASS to **request derived keys from new contexts and use the generated keys to sign Cookies**.
+Therefore, even if the PRT cannot be extracted because it's located inside the TPM, it's possible to abuseLSASS to **request derived keys from new contexts and use the generated keys to sign Cookies**.
 
 <figure><img src="../../../.gitbook/assets/image (31).png" alt=""><figcaption></figcaption></figure>
 
@@ -126,7 +126,7 @@ Connect-AzureAD --AadAccessToken <token> --AccountId <acc_ind>
 
 ### Attack - Using roadrecon
 
-### Attack - Using AADInternals an leaked PTR
+### Attack - Using AADInternals and a leaked PRT
 
 `Get-AADIntUserPRTToken` **gets user’s PRT token** from the Azure AD joined or Hybrid joined computer. Uses `BrowserCore.exe` to get the PRT token.
 
@@ -269,7 +269,7 @@ HttpOnly: Set to True (checked)
 The rest should be the defaults. Make sure you can refresh the page and the cookie doesn’t disappear, if it does, you may have made a mistake and have to go through the process again. If it doesn’t, you should be good.
 {% endhint %}
 
-#### Option 2 - roadrecon using PTR
+#### Option 2 - roadrecon using PRT
 
 * Renew the PRT first, which will save it in `roadtx.prt`:
 


### PR DESCRIPTION
Replaced several instances of PTR when PRT was intended acronym.

You can remove this content before sending the PR:

## Attribution
We value your knowledge and encourage you to share content. Please ensure that you only upload content that you own or that have permission to share it from the original author (adding a reference to the author in the added text or at the end of the page you are modifying or both). Your respect for intellectual property rights fosters a trustworthy and legal sharing environment for everyone.

## HackTricks Training
If you are adding so you can pass the in the [ARTE certification](https://training.hacktricks.xyz/courses/arte) exam with 2 flags instead of 3, you need to call the PR `arte-<username>`.

Also, remember that grammar/syntax fixes won't be accepted for the exam flag reduction.


In any case, thanks for contributing to HackTricks!
