### PR TITLE
Adding best practices for local file parameters with KMS Decrypt

### DIFF
--- a/pentesting-cloud/aws-pentesting/aws-post-exploitation/aws-kms-post-exploitation.md
+++ b/pentesting-cloud/aws-pentesting/aws-post-exploitation/aws-kms-post-exploitation.md
@@ -65,6 +65,15 @@ aws kms decrypt \
     --query Plaintext | base64 \
     --decode
 ```
+{% hint style="warning" %}
+The use of **`file://`** grants you the convenience of using files written in your preferred encoding when using the CLI.
+In versions 1.6.3 and higher of the CLI, you have access to another way to pass the contents of a file to the CLI, **`fileb://`**. It works similiar to **`file://`**, but instead of reading the contents of the file as text, it is read as binary
+
+For most cases, **`file://`** will satisfy your use case for passing the contents of a file as input. However, there are some cases where **`fileb://`** must be used to pass the contents of the file in as binary as opposed to as text.
+Read more from AWS here: [AWS Blog - Best Practice for Local File Parameters](https://aws.amazon.com/blogs/developer/best-practices-for-local-file-parameters/)
+
+If recieving the error 'An error occurred (InvalidCiphertextException) when calling the Decrypt operation:' when attempting to peform kms decrypt try using **`--ciphertext-blob file://`** instead of **`fileb://`**.
+{% endhint %}
 
 ### KMS Ransomware
 

--- a/pentesting-cloud/aws-pentesting/aws-post-exploitation/aws-kms-post-exploitation.md
+++ b/pentesting-cloud/aws-pentesting/aws-post-exploitation/aws-kms-post-exploitation.md
@@ -66,13 +66,13 @@ aws kms decrypt \
     --decode
 ```
 {% hint style="warning" %}
+If recieving the error 'An error occurred (InvalidCiphertextException) when calling the Decrypt operation:' when attempting to peform kms decrypt try using **`--ciphertext-blob file://`** instead of **`fileb://`**.
+
 The use of **`file://`** grants you the convenience of using files written in your preferred encoding when using the CLI.
 In versions 1.6.3 and higher of the CLI, you have access to another way to pass the contents of a file to the CLI, **`fileb://`**. It works similiar to **`file://`**, but instead of reading the contents of the file as text, it is read as binary
 
 For most cases, **`file://`** will satisfy your use case for passing the contents of a file as input. However, there are some cases where **`fileb://`** must be used to pass the contents of the file in as binary as opposed to as text.
 Read more from AWS here: [AWS Blog - Best Practice for Local File Parameters](https://aws.amazon.com/blogs/developer/best-practices-for-local-file-parameters/)
-
-If recieving the error 'An error occurred (InvalidCiphertextException) when calling the Decrypt operation:' when attempting to peform kms decrypt try using **`--ciphertext-blob file://`** instead of **`fileb://`**.
 {% endhint %}
 
 ### KMS Ransomware


### PR DESCRIPTION
Adding a tip/warning for best practices for local file parameters with KMS Decrypt