### PR TITLE
Update aws-apigateway-privesc.md

### DIFF
--- a/pentesting-cloud/aws-security/aws-privilege-escalation/aws-apigateway-privesc.md
+++ b/pentesting-cloud/aws-security/aws-privilege-escalation/aws-apigateway-privesc.md
@@ -37,7 +37,7 @@ aws --region <region> apigateway create-api-key
 With this permission you can get generated API keys of the APIs configured (per region).
 
 ```bash
-aws --region apigateway get-api-keys
+aws --region <region> apigateway get-api-keys
 aws --region <region> apigateway get-api-key --api-key <key> --include-value
 ```
 


### PR DESCRIPTION
Corrected the syntax on the AWS CLI command by adding the missing <region> tag on line 40.
