### PR TITLE
Fix typo: Kuebelet -> Kubelet

### DIFF
--- a/pentesting-cloud/kubernetes-security/pentesting-kubernetes-services.md
+++ b/pentesting-cloud/kubernetes-security/pentesting-kubernetes-services.md
@@ -164,7 +164,7 @@ The [**Kubelet documentation**](https://kubernetes.io/docs/reference/command-lin
 
 > Enables anonymous requests to the Kubelet server. Requests that are not rejected by another authentication method are treated as anonymous requests. Anonymous requests have a username of `system:anonymous`, and a group name of `system:unauthenticated`
 
-To understand better how the **authentication and authorization of the Kuebelet API works** check this page:
+To understand better how the **authentication and authorization of the Kubelet API works** check this page:
 
 {% content-ref url="../kubernetes-pentesting/pentesting-kubernetes-services/kubelet-authentication-and-authorization.md" %}
 [kubelet-authentication-and-authorization.md](../kubernetes-pentesting/pentesting-kubernetes-services/kubelet-authentication-and-authorization.md)

--- a/pentesting-cloud/kubernetes-security/pentesting-kubernetes-services/README.md
+++ b/pentesting-cloud/kubernetes-security/pentesting-kubernetes-services/README.md
@@ -164,7 +164,7 @@ The [**Kubelet documentation**](https://kubernetes.io/docs/reference/command-lin
 
 > Enables anonymous requests to the Kubelet server. Requests that are not rejected by another authentication method are treated as anonymous requests. Anonymous requests have a username of `system:anonymous`, and a group name of `system:unauthenticated`
 
-To understand better how the **authentication and authorization of the Kuebelet API works** check this page:
+To understand better how the **authentication and authorization of the Kubelet API works** check this page:
 
 {% content-ref url="kubelet-authentication-and-authorization.md" %}
 [kubelet-authentication-and-authorization.md](kubelet-authentication-and-authorization.md)


### PR DESCRIPTION
Just fixing simple typo. Nothing fancy.