### PR TITLE
Fix spelling of persistence

### DIFF
--- a/pentesting-cloud/aws-security/aws-persistence/aws-ssm-persistence.md
+++ b/pentesting-cloud/aws-security/aws-persistence/aws-ssm-persistence.md
@@ -1,4 +1,4 @@
-# AWS - SSM Perssitence
+# AWS - SSM Persistence
 
 
 


### PR DESCRIPTION
## Changes:
- Fix spelling of `persistence` in [aws-ssm-perssitence](https://cloud.hacktricks.xyz/pentesting-cloud/aws-security/aws-persistence/aws-ssm-perssitence)
