### PR TITLE
Update gcp-federation-abuse.md

### DIFF
--- a/pentesting-cloud/gcp-security/gcp-basic-information/gcp-federation-abuse.md
+++ b/pentesting-cloud/gcp-security/gcp-basic-information/gcp-federation-abuse.md
@@ -151,9 +151,9 @@ jobs:
       uses: 'google-github-actions/auth@v2.1.3'
       with:
           create_credentials_file: 'true'
-          workload_identity_provider: '${providerId}'
-          service_account: '${saId}'
-          activate_credentials_file: true
+          workload_identity_provider: '${providerId}' # In the providerId, the numerical project ID (12 digit number) should be used 
+          service_account: '${saId}'                  # instead of the alphanumeric project ID. ex: 
+          activate_credentials_file: true             # projects/123123123123/locations/global/workloadIdentityPools/iam-lab-7-gh-pool/providers/iam-lab-7-gh-pool-oidc-provider' 
     - id: 'gcloud'
       name: 'gcloud'
       run: |-


### PR DESCRIPTION
Fixed the GitHub Action YAML file to indicate that the project ID in the workload_identity_provider field should in fact be the numerical variant instead of the alphanumeric variant.
