### PR TITLE
Updated broken link to new hosting

### DIFF
--- a/pentesting-ci-cd/jenkins-security/README.md
+++ b/pentesting-ci-cd/jenkins-security/README.md
@@ -81,7 +81,7 @@ Many organizations combine **SaaS-based source control management (SCM) systems*
 
 To achieve this, organizations **whitelist** the **IP ranges** of the **SCM platforms**, permitting them to access the **internal CI system** via **webhooks**. However, it's important to note that **anyone** can create an **account** on GitHub or GitLab and configure it to **trigger a webhook**, potentially sending requests to the **internal CI system**.
 
-Check: [shttps://www.cidersecurity.io/blog/research/how-we-abused-repository-webhooks-to-access-internal-ci-systems-at-scale/](https://www.cidersecurity.io/blog/research/how-we-abused-repository-webhooks-to-access-internal-ci-systems-at-scale/)
+Check: [https://www.paloaltonetworks.com/blog/prisma-cloud/repository-webhook-abuse-access-ci-cd-systems-at-scale/](https://www.paloaltonetworks.com/blog/prisma-cloud/repository-webhook-abuse-access-ci-cd-systems-at-scale//)
 
 ## Internal Jenkins Abuses
 


### PR DESCRIPTION
Fixed broken link to Cider Security (Acquired by Palo Alto Networks)