### PR TITLE
Remove Invalid awsgatewayv2 Commands

### DIFF
--- a/pentesting-cloud/aws-security/aws-services/aws-api-gateway-enum.md
+++ b/pentesting-cloud/aws-security/aws-services/aws-api-gateway-enum.md
@@ -96,12 +96,9 @@ aws apigateway get-usage --usage-plan-id <plan_id> --start-date 2023-07-01 --end
 {% tab title="apigatewayv2" %}
 ```bash
 # Generic info
-aws apigatewayv2 get-account --
 aws apigatewayv2 get-domain-names
 aws apigatewayv2 get-domain-name --domain-name <name>
-aws apigatewayv2 get-usage-plans --
 aws apigatewayv2 get-vpc-links
-aws apigatewayv2 get-client-certificates --
 
 # Enumerate APIs
 aws apigatewayv2 get-apis # This will also show the resource policy (if any)


### PR DESCRIPTION
```
└─$ aws --version                            
aws-cli/1.29.54 Python/3.11.9 Linux/6.8.11-amd64 awscrt/1.0.0.dev0 botocore/1.31.54
```

There were several commands which don't or no longer exist.

List of [commands](https://docs.aws.amazon.com/cli/latest/reference/apigatewayv2/):

```
└─$ aws apigatewayv2 get-client-certificates --profile arte
Note: AWS CLI version 2, the latest major version of the AWS CLI, is now stable and recommended for general use. For more information, see the AWS CLI version 2 installation instructions at: https://docs.aws.amazon.com/cli/latest/userguide/install-cliv2.html

usage: aws [options] <command> <subcommand> [<subcommand> ...] [parameters]
To see help text, you can run:

  aws help
  aws <command> help
  aws <command> <subcommand> help
aws: error: argument operation: Invalid choice, valid choices are:

create-api                               | create-api-mapping                      
create-authorizer                        | create-deployment                       
create-domain-name                       | create-integration                      
create-integration-response              | create-model                            
create-route                             | create-route-response                   
create-stage                             | create-vpc-link                         
delete-access-log-settings               | delete-api                              
delete-api-mapping                       | delete-authorizer                       
delete-cors-configuration                | delete-deployment                       
delete-domain-name                       | delete-integration                      
delete-integration-response              | delete-model                            
delete-route                             | delete-route-request-parameter          
delete-route-response                    | delete-route-settings                   
delete-stage                             | delete-vpc-link                         
export-api                               | reset-authorizers-cache                 
get-api                                  | get-api-mapping                         
get-api-mappings                         | get-apis                                
get-authorizer                           | get-authorizers                         
get-deployment                           | get-deployments                         
get-domain-name                          | get-domain-names                        
get-integration                          | get-integration-response                
get-integration-responses                | get-integrations                        
get-model                                | get-model-template                      
get-models                               | get-route                               
get-route-response                       | get-route-responses                     
get-routes                               | get-stage                               
get-stages                               | get-tags                                
get-vpc-link                             | get-vpc-links                           
import-api                               | reimport-api                            
tag-resource                             | untag-resource                          
update-api                               | update-api-mapping                      
update-authorizer                        | update-deployment                       
update-domain-name                       | update-integration                      
update-integration-response              | update-model                            
update-route                             | update-route-response                   
update-stage                             | update-vpc-link                         
help 
```