### PR TITLE
remove stray 'ole'

### DIFF
--- a/pentesting-cloud/aws-security/aws-privilege-escalation/aws-cognito-privesc.md
+++ b/pentesting-cloud/aws-security/aws-privilege-escalation/aws-cognito-privesc.md
@@ -44,7 +44,7 @@ aws cognito-identity set-identity-pool-roles \
 ## Get one ID
 aws cognito-identity get-id --identity-pool-id "eu-west-2:38b294756-2578-8246-9074-5367fc9f5367"
 ## Get creds for that id
-aws cognito-identity get-credentials-for-identity --identity-id "eu-west-2:195f9c73-4789-4bb4-4376-99819b6928374" ole
+aws cognito-identity get-credentials-for-identity --identity-id "eu-west-2:195f9c73-4789-4bb4-4376-99819b6928374"
 ```
 
 If the cognito app **doesn't have unauthenticated users enabled** you might need also the permission `cognito-identity:UpdateIdentityPool` to enable it.


### PR DESCRIPTION
There were a few stray characters at the end of a command, remove them.