### PR TITLE
Change pyrebase to pyrebase4

### DIFF
--- a/pentesting-cloud/gcp-security/gcp-services/gcp-firebase-enum.md
+++ b/pentesting-cloud/gcp-security/gcp-services/gcp-firebase-enum.md
@@ -50,6 +50,7 @@ If you have credentials to access the Firebase database you can use a tool such 
 
 ```python
 #Taken from https://blog.assetnote.io/bug-bounty/2020/02/01/expanding-attack-surface-react-native/
+#Install pyrebase: pip install pyrebase4
 import pyrebase
 
 config = {
@@ -66,7 +67,7 @@ db = firebase.database()
 print(db.get())
 ```
 
-To test other actions on the database, such as writing to the database, refer to the Pyrebase documentation which can be found [here](https://github.com/thisbejim/Pyrebase).
+To test other actions on the database, such as writing to the database, refer to the Pyrebase4 documentation which can be found [here](https://github.com/nhorvath/Pyrebase4).
 
 ### Access info with APPID and API Key <a href="#access-info-with-appid-and-api-key" id="access-info-with-appid-and-api-key"></a>
 


### PR DESCRIPTION
The pyrebase repo has not been updated for 4 years (at the time of writing) and no longer works on recent python versions (3.10+).

Pyrebase4 is more recent and seems to be maintained.

You can remove this content before sending the PR:

## Attribution
We value your knowledge and encourage you to share content. Please ensure that you only upload content that you own or that have permission to share it from the original author (adding a reference to the author in the added text or at the end of the page you are modifying or both). Your respect for intellectual property rights fosters a trustworthy and legal sharing environment for everyone.