### PR TITLE
Fixed Invoke-Monkey365 using -IncludeEntraID instead of -IncludeAzure…

### DIFF
--- a/pentesting-cloud/azure-security/README.md
+++ b/pentesting-cloud/azure-security/README.md
@@ -192,7 +192,7 @@ roadrecon gui
 Import-Module monkey365
 Get-Help Invoke-Monkey365
 Get-Help Invoke-Monkey365 -Detailed
-Invoke-Monkey365 -IncludeAzureActiveDirectory -ExportTo HTML -Verbose -Debug -InformationAction Continue
+Invoke-Monkey365 -IncludeEntraID -ExportTo HTML -Verbose -Debug -InformationAction Continue
 Invoke-Monkey365 - Instance Azure -Analysis All -ExportTo HTML
 ```
 {% endcode %}


### PR DESCRIPTION
As the title says the syntax has changed.
