### PR TITLE
arte-ex16x41

### DIFF
--- a/pentesting-cloud/aws-pentesting/aws-post-exploitation/aws-sts-post-exploitation.md
+++ b/pentesting-cloud/aws-pentesting/aws-post-exploitation/aws-sts-post-exploitation.md
@@ -23,6 +23,44 @@ For more information:
 [aws-iam-enum.md](../../aws-security/aws-services/aws-iam-enum.md)
 {% endcontent-ref %}
 
+#### New Method December 2024: Bypass Requirement for Web Console Link, By HTTPS POST Request To SecretsManager API Directly Obtain Secrets (No Login Link Or Web Console)
+
+Submitted yesterday, as PR for upcoming exam (ARTE: ex16x41) however I see that the PR doesn't show, maybe submitted wrong, let's try again: 
+Using this method you completely bypass the requirement for opening any URLs, formatting any login links or even using the CLI / Web Console.
+So what did we do here?
+I wrote this script that interacts with the AWS Secrets Manager API directly, it is absolutley simple and straightforward.
+When you run the script, it sends an HTTPS POST request to the AWS Secrets Manager endpoint
+https://secretsmanager.<region>.amazonaws.com/
+The GetSecretValue request is sent as part of the POST request, authenticated with SigV4 signing (managed by boto3).
+Secrets Manager Processes the Request:
+AWS validates the request against the IAM policies attached to your user or role (as we know we can view the secret value only as web console)
+If allowed, the Secrets Manager service returns the requested secret value in the response.
+**POC Demo:**
+The CLI AWS command to get secret value is not working because access denied ->
+However, in the image you can see the simplicity of the method to simply extract the flag directly by knowing secret ID (this we enum in earlier stage when logged in with user profile) 
+![image](https://github.com/user-attachments/assets/d05a1a96-04c0-4404-b4bd-dbfa93c6494b)
+Note: I think this method can be used universally depending on the scenario if policy allows (but bypass restrictions of policy that doe snot allow via CLI) 
+So this can be used anytime a policy allows (as an alternative test option) 
+Side Note: curious about other techniques you can apply using same method of direct interaction with the API of service and now AWS CLI, for any process of priv esc or post exploitation like here. 
+**Code:**
+'''
+Python 
+import boto3
+
+session = boto3.Session(profile_name="lab6")
+client = session.client("secretsmanager", region_name="us-east-1")
+
+# Set a custom User-Agent
+client.meta.events.register(
+    'before-call.secretsmanager.GetSecretValue',
+    lambda params, **kwargs: params['headers'].update({'User-Agent': 'my-custom-tool'})
+)
+
+# Retrieve the secret value directly via secretsmanager API
+response = client.get_secret_value(SecretId="flag_sts_lab_3")
+print(response['SecretString'])
+'''
+
 ### From IAM Creds to Console
 
 If you have managed to obtain some IAM credentials you might be interested on **accessing the web console** using the following tools.\


### PR DESCRIPTION
Discovered a method to bypass IAM policy restrictions on AWS Secrets Manager. By using direct API calls, secrets can be accessed even when policies enforce access only via the web console or AWS CLI—successfully bypassing StringNotLike conditions for aws:UserAgent.

While API calls are well-documented in AWS as a general concept, this practical technique highlights a real-world vulnerability in IAM policy configurations. If policies allow viewing secret values of user (authenticated via credentials in aws cli), this method can universally bypass restrictions that block CLI requests.

Test Case: This was tested on a lab sts:GetFederationToken to access the web console for retrieving a secret flag. Instead of using the console, or generating temp creds for console access-> the secret was extracted directly via API by sending an HTTPS POST Request to SecretsManager (with Sigv4) This technique might be prevented by multi-factor authentication or stricter policies, such as enforcing specific aws:SourceIp.

Security Improvement: Stricter IAM policies, like allowing requests only from specific IP ranges or host, could mitigate this. However, attackers might explore spoofing as a potential bypass.

Proposed Update: This finding could fit well under "SecretsManager Post Exploitation" in HackTricks resources.

Upon reviewing the HackTricks resources, including the https://cloud.hacktricks.xyz - there is no explicit mention of using direct API calls to AWS Secrets Manager to bypass IAM policy restrictions, such as conditions on aws:UserAgent

Check the demo POC image in the commit. To test, authenticate as the lab user with sts:GetFederationToken, update the Python script by replacing the profile name with yours, and run it as-is.

Thank you! :)
Kind Regards.