### PR TITLE
Updated Cognito Identity CLI Command Format

### DIFF
--- a/src/pentesting-cloud/aws-security/aws-services/aws-cognito-enum/cognito-identity-pools.md
+++ b/src/pentesting-cloud/aws-security/aws-services/aws-cognito-enum/cognito-identity-pools.md
@@ -167,22 +167,36 @@ For this you might need to have access to the **identity provider**. If that is 
 
 Anyway, the **following example** expects that you have already logged in inside a **Cognito User Pool** used to access the Identity Pool (don't forget that other types of identity providers could also be configured).
 
-<pre class="language-bash"><code class="lang-bash">aws cognito-identity get-id \
-    --identity-pool-id <identity_pool_id> \
-    --logins cognito-idp.<region>.amazonaws.com/<YOUR_USER_POOL_ID>=<ID_TOKEN>
+<pre class="language-bash"><code class="lang-bash">
+# Updated format
+aws cognito-identity get-id \
+  --identity-pool-id <identity_pool_id> \
+  --logins '{"cognito-idp.<region>.amazonaws.com/<user_pool_id>": "<ID_TOKEN>"}'
 
-# Get the identity_id from the previous commnad response
 aws cognito-identity get-credentials-for-identity \
-    --identity-id <identity_id> \
-    --logins cognito-idp.<region>.amazonaws.com/<YOUR_USER_POOL_ID>=<ID_TOKEN>
+  --identity-id <identity_id> \
+  --logins '{"cognito-idp.<region>.amazonaws.com/<user_pool_id>": "<ID_TOKEN>"}'
 
-
-# In the IdToken you can find roles a user has access because of User Pool Groups
-# User the --custom-role-arn to get credentials to a specific role
 aws cognito-identity get-credentials-for-identity \
-    --identity-id <identity_id> \
-<strong>    --custom-role-arn <role_arn> \
-</strong>    --logins cognito-idp.<region>.amazonaws.com/<YOUR_USER_POOL_ID>=<ID_TOKEN>
+  --identity-id <identity_id> \
+  --custom-role-arn <role_arn> \
+  --logins '{"cognito-idp.<region>.amazonaws.com/<user_pool_id>": "<ID_TOKEN>"}'
+</code></pre>
+
+> **Deprecated format** — these may no longer work with current AWS CLI:
+<pre class="language-bash"><code class="lang-bash">
+aws cognito-identity get-id \
+  --identity-pool-id <identity_pool_id> \
+  --logins cognito-idp.<region>.amazonaws.com/<user_pool_id>=<ID_TOKEN>
+
+aws cognito-identity get-credentials-for-identity \
+  --identity-id <identity_id> \
+  --logins cognito-idp.<region>.amazonaws.com/<user_pool_id>=<ID_TOKEN>
+
+aws cognito-identity get-credentials-for-identity \
+  --identity-id <identity_id> \
+  --custom-role-arn <role_arn> \
+  --logins cognito-idp.<region>.amazonaws.com/<user_pool_id>=<ID_TOKEN>
 </code></pre>
 
 > [!WARNING]


### PR DESCRIPTION
Replaced outdated key=value syntax with JSON-based in "--logins" format, keeping the old format for preserved legacy.

You can remove this content before sending the PR:

## Attribution
We value your knowledge and encourage you to share content. Please ensure that you only upload content that you own or that have permission to share it from the original author (adding a reference to the author in the added text or at the end of the page you are modifying or both). Your respect for intellectual property rights fosters a trustworthy and legal sharing environment for everyone.

## HackTricks Training
If you are adding so you can pass the in the [ARTE certification](https://training.hacktricks.xyz/courses/arte) exam with 2 flags instead of 3, you need to call the PR `arte-<username>`.

Also, remember that grammar/syntax fixes won't be accepted for the exam flag reduction.


In any case, thanks for contributing to HackTricks!




