### PR TITLE
Clarify Kubernetes node placement attack permissions

### DIFF
--- a/src/pentesting-cloud/kubernetes-security/abusing-roles-clusterroles-in-kubernetes/README.md
+++ b/src/pentesting-cloud/kubernetes-security/abusing-roles-clusterroles-in-kubernetes/README.md
@@ -701,17 +701,23 @@ websocat --insecure \
 
 ### Delete pods + unschedulable nodes
 
-Principals that can **delete pods** (`delete` verb over `pods` resource), or **evict pods** (`create` verb over `pods/eviction` resource), or **change pod status** (access to `pods/status`) and can **make other nodes unschedulable** (access to `nodes/status`) or **delete nodes** (`delete` verb over `nodes` resource) and has control over a pod, could **steal pods from other nodes** so they are **executed** in the **compromised** **node** and the attacker can **steal the tokens** from those pods.
+An attacker can bring a controller-managed Pod to a compromised node by combining two capabilities:
+
+1. **Cause a replacement:** delete the target Pod (`delete` on `pods`), evict it (`create` on `pods/eviction`), or make an accepted status change that causes its controller to replace it (`patch` or `update` on `pods/status`). A bare Pod is not recreated, and eviction may be blocked by a PodDisruptionBudget.
+2. **Exclude competing nodes:** patch every other eligible node's `status.allocatable.pods` to `0` (`patch` or `update` on `nodes/status`), or use another placement control such as deleting or cordoning those Nodes. If the compromised node satisfies the Pod's remaining requirements, the scheduler places the replacement there.
+
+Kubelets periodically restore their real reported capacity, so the status changes may need to be maintained until scheduling finishes.
+
+{% hint style="warning" %}
+A normal `system:node:<node-name>` identity does **not** have this complete attack path when the Node authorizer and NodeRestriction admission plugin are enabled. It can delete or evict only Pods assigned to itself and can modify only its own Node. Therefore, default node credentials cannot delete a target Pod on another node or remove the other nodes from consideration. The technique requires a broader non-node credential, or a cluster without effective NodeRestriction.<sup>[[47]](#references)[[48]](#references)</sup>
+{% endhint %}
 
 ```bash
-patch_node_capacity(){
-    curl -s -X PATCH 127.0.0.1:8001/api/v1/nodes/$1/status -H "Content-Type: json-patch+json" -d '[{"op": "replace", "path":"/status/allocatable/pods", "value": "0"}]'
-}
+# Make a competing node report zero Pod slots; repeat for every eligible node except the compromised node.
+kubectl patch node <competing-node> --subresource=status --type=json -p='[{"op":"replace","path":"/status/allocatable/pods","value":"0"}]'
 
-while true; do patch_node_capacity <id_other_node>; done &
-#Launch previous line with all the nodes you need to attack
-
-kubectl delete pods -n kube-system <privileged_pod_name>
+# Delete the controller-managed target Pod so its controller creates a replacement.
+kubectl delete pod <target-pod> -n <namespace>
 ```
 
 ### Services status (CVE-2020-8554)
@@ -905,5 +911,7 @@ https://github.com/aquasecurity/kube-bench
 - [44] [ipc_namespaces(7)](https://www.man7.org/linux/man-pages/man7/ipc_namespaces.7.html)
 - [45] [network_namespaces(7)](https://www.man7.org/linux/man-pages/man7/network_namespaces.7.html)
 - [46] [pid_namespaces(7)](https://man7.org/linux/man-pages/man7/pid_namespaces.7.html)
+- [47] [Node authorization](https://kubernetes.io/docs/reference/access-authn-authz/node/)
+- [48] [NodeRestriction admission plugin](https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/#noderestriction)
 
 {{#include ../../../banners/hacktricks-training.md}}


### PR DESCRIPTION
## Summary

- split the Pod-stealing technique into the replacement and placement capabilities it requires
- clarify that Node authorization and NodeRestriction prevent default node credentials from targeting remote Pods or competing Nodes
- replace the old proxy loop with focused kubectl examples and add official Kubernetes references

## Validation

- `git diff --check`
- `mdbook build -d /tmp/htc-mdbook-output.HI1q01` attempted; blocked because `mdbook-tabs` is not installed in the local environment