### PR TITLE
Expand Kubernetes node post-exploitation guidance

### DIFF
--- a/src/pentesting-cloud/kubernetes-security/attacking-kubernetes-from-inside-a-pod.md
+++ b/src/pentesting-cloud/kubernetes-security/attacking-kubernetes-from-inside-a-pod.md
@@ -169,26 +169,68 @@ kubectl --namespace big-monolith top pod hunger-check-deployment-xxxxxxxxxx-xxxx
 
 ## Node Post-Exploitation
 
-If you managed to **escape from the container** there are some interesting things you will find in the node:
+After escaping to a Kubernetes host, first determine whether it is a **worker**, a **self-managed control-plane node**, or a host that combines both roles. Workers normally run application Pods. Self-managed control-plane nodes also commonly run kubelet, but are usually tainted to prevent ordinary workloads from being scheduled there. In managed Kubernetes services, the provider's control-plane hosts are normally not accessible to customers.
 
-- The **Container Runtime** process (Docker)
-- More **pods/containers** running in the node you can abuse like this one (more tokens)
-- The whole **filesystem** and **OS** in general
-- The **Kube-Proxy** service listening
-- The **Kubelet** service listening. Check config files:
-  - Directory: `/var/lib/kubelet/`
-    - `/var/lib/kubelet/kubeconfig`
-    - `/var/lib/kubelet/kubelet.conf`
-    - `/var/lib/kubelet/config.yaml`
-    - `/var/lib/kubelet/kubeadm-flags.env`
-    - `/etc/kubernetes/kubelet-kubeconfig`
-    - `/etc/kubernetes/admin.conf` --> `kubectl --kubeconfig /etc/kubernetes/admin.conf get all -n kube-system`
-  - Other **kubernetes common files**:
-    - `$HOME/.kube/config` - **User Config**
-    - `/etc/kubernetes/kubelet.conf`- **Regular Config**
-    - `/etc/kubernetes/bootstrap-kubelet.conf` - **Bootstrap Config**
-    - `/etc/kubernetes/manifests/etcd.yaml` - **etcd Configuration**
-    - `/etc/kubernetes/pki` - **Kubernetes Key**
+Modern Kubernetes nodes normally use a CRI runtime such as **containerd** or **CRI-O**, not Docker Engine. Host access can expose the kubelet, the runtime socket, CNI and kube-proxy state, Pod files and logs, node or cloud credentials, and every workload currently running on that host.<sup>[[30]](#references)[[31]](#references)</sup>
+
+### Kubelet credentials and local API
+
+Useful kubelet paths commonly include `/var/lib/kubelet/config.yaml`, `/var/lib/kubelet/kubeconfig`, `/etc/kubernetes/kubelet.conf`, `/etc/kubernetes/bootstrap-kubelet.conf`, and distribution-specific equivalents. Inspect the running process or service definition because these paths are configurable.
+
+```bash
+# Identify the kubelet configuration and kubeconfig paths used by the running process.
+ps -ef | grep '[k]ubelet'
+
+# Check whether the active kubelet credential can read a known Pod assigned to this node.
+kubectl --kubeconfig /var/lib/kubelet/kubeconfig auth can-i get pod/<pod-on-this-node> -n <namespace>
+```
+
+A kubelet credential normally authenticates as `system:node:<node-name>`. With Node authorization and NodeRestriction, it should be limited to its own Node and objects related to Pods assigned there; it is not automatically cluster-admin.<sup>[[32]](#references)[[33]](#references)</sup>
+
+Compromising the host also does **not** automatically authorize requests to `https://127.0.0.1:10250`. The kubelet still authenticates and authorizes the credential presented to its HTTPS API. Root can usually inspect local files and use the runtime socket directly, but accessing kubelet endpoints requires an accepted client certificate, bearer token, or an insecure kubelet configuration.
+
+### CRI runtime, containers, and filesystems
+
+`crictl` is a command-line client for CRI-compatible runtimes. It is commonly present on Kubernetes nodes for troubleshooting but is not guaranteed to be installed. Its configured endpoint, the kubelet flags, and running processes reveal whether the node uses containerd, CRI-O, or another runtime.<sup>[[30]](#references)[[34]](#references)</sup>
+
+```bash
+# Show the CRI endpoint and runtime information used by crictl.
+crictl info
+
+# Enumerate Pod sandboxes managed by the local runtime.
+crictl pods
+
+# Enumerate running and stopped containers managed by the local runtime.
+crictl ps -a
+
+# Inspect a container's runtime metadata; this does not list or read its files.
+crictl inspect <container-id>
+```
+
+A Pod does not have one root filesystem. Each container has its own filesystem assembled from image layers and a writable layer. There are three practical ways to access it from the node:
+
+- **Runtime exec:** use `crictl exec` for a running container. This asks the runtime to start a process inside the container and is normally the simplest supported method.
+- **Mounted root through `/proc`:** obtain the running container's host PID from runtime metadata, then browse `/proc/<pid>/root`. This accesses the already mounted root filesystem without starting a process inside the container.
+- **Runtime storage:** containerd with the overlayfs snapshotter commonly stores snapshots below `/var/lib/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/`; CRI-O commonly uses `/var/lib/containers/storage/overlay/`. These locations are configurable implementation details, and their directory IDs need not equal the Kubernetes Pod UID or container ID. Prefer runtime metadata and supported clients instead of guessing or modifying snapshot directories.
+
+```bash
+# Start a shell through the runtime inside a running container.
+crictl exec -it <container-id> sh
+
+# Obtain the running container's host PID from containerd CRI metadata.
+CONTAINER_PID=$(crictl inspect <container-id> | jq -r '.info.pid')
+
+# Browse the container's mounted root filesystem without executing inside it.
+ls -la "/proc/${CONTAINER_PID}/root"
+```
+
+`/var/lib/kubelet/pods/<pod-uid>` normally contains kubelet state and volume mount points, **not** a container's complete root filesystem. Also inspect `/var/log/pods`, `/var/log/containers`, mounted Secret and projected-token volumes, persistent volumes, and application-specific paths. The runtime sockets—commonly `/run/containerd/containerd.sock` or `/var/run/crio/crio.sock`—provide powerful local control outside Kubernetes RBAC; write access to an active socket should usually be treated as node-level compromise.
+
+### Control-plane node artifacts
+
+Control-plane nodes usually do not run ordinary application Pods, but local compromise can expose more powerful cluster components. Look for active administrator and component kubeconfigs such as `admin.conf`, `controller-manager.conf`, and `scheduler.conf`; API-server client and serving keys; a client-CA private key; ServiceAccount signing keys; encryption-provider configuration or KMS connection material; writable static-Pod manifests; and etcd client credentials or data.<sup>[[35]](#references)</sup>
+
+The impact depends on which component the host runs. Administrator kubeconfigs can provide immediate API access; controller and scheduler credentials are usually narrower; a client-CA private key can mint accepted client certificates; a ServiceAccount signing key can forge accepted tokens when their issuer and verification settings match; and static-manifest write access can alter control-plane components outside ordinary workload admission. **Write access to the active etcd database is full cluster compromise** because it can directly modify Kubernetes state, including RBAC and workloads, without API-server authorization, admission, or API audit logging. Do not test this by writing to live etcd because malformed state can corrupt the cluster.
 
 ### Image Pull and Registry Credentials
 
@@ -489,5 +531,11 @@ Off-Menu         +
 - [27] [Attacking Kubernetes Clusters Through Your Network Plumbing: Part 1 | CyberArk](https://www.cyberark.com/resources/threat-research-blog/attacking-kubernetes-clusters-through-your-network-plumbing-part-1)
 - [28] [DNS Spoofing on Kubernetes Clusters | Aqua](https://www.aquasec.com/blog/dns-spoofing-kubernetes-clusters/)
 - [29] [Command and kubectl talk follow-up | NCC Group](https://research.nccgroup.com/2020/02/12/command-and-kubectl-talk-follow-up/)
+- [30] [Container runtimes | Kubernetes](https://kubernetes.io/docs/setup/production-environment/container-runtimes/)
+- [31] [Debugging Kubernetes nodes with crictl | Kubernetes](https://kubernetes.io/docs/tasks/debug/debug-cluster/crictl/)
+- [32] [Node authorization | Kubernetes](https://kubernetes.io/docs/reference/access-authn-authz/node/)
+- [33] [NodeRestriction admission plugin | Kubernetes](https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/#noderestriction)
+- [34] [cri-tools and crictl | Kubernetes SIG Node](https://github.com/kubernetes-sigs/cri-tools)
+- [35] [Implementation details | kubeadm](https://kubernetes.io/docs/reference/setup-tools/kubeadm/implementation-details/)
 
 {{#include ../../banners/hacktricks-training.md}}


### PR DESCRIPTION
## Summary

- distinguish worker, self-managed control-plane, combined, and provider-managed node exposure
- replace the Docker-centric runtime description with current CRI/containerd/CRI-O guidance
- explain kubelet credential and local API authorization boundaries
- document CRI enumeration and supported ways to inspect container filesystems from the host
- clarify kubelet Pod directories, runtime sockets, control-plane credentials, and etcd write impact

## Validation

- `git diff --check`
- Markdown fence and reference checks
- command examples reviewed against current Kubernetes and cri-tools documentation
- full `mdbook build` is blocked in this local environment because the repository-required `mdbook-tabs` preprocessor is not installed